### PR TITLE
fix: 커피챗 성사시 active처리 오류 해결

### DIFF
--- a/src/main/generated/com/soongsil/CoffeeChat/dto/QPossibleDateRequestDto.java
+++ b/src/main/generated/com/soongsil/CoffeeChat/dto/QPossibleDateRequestDto.java
@@ -13,8 +13,8 @@ public class QPossibleDateRequestDto extends ConstructorExpression<PossibleDateR
 
     private static final long serialVersionUID = -203748687L;
 
-    public QPossibleDateRequestDto(com.querydsl.core.types.Expression<java.time.LocalDate> date, com.querydsl.core.types.Expression<java.time.LocalTime> startTime, com.querydsl.core.types.Expression<java.time.LocalTime> endTime) {
-        super(PossibleDateRequestDto.class, new Class<?>[]{java.time.LocalDate.class, java.time.LocalTime.class, java.time.LocalTime.class}, date, startTime, endTime);
+    public QPossibleDateRequestDto(com.querydsl.core.types.Expression<java.time.LocalDate> date, com.querydsl.core.types.Expression<java.time.LocalTime> startTime, com.querydsl.core.types.Expression<java.time.LocalTime> endTime, com.querydsl.core.types.Expression<Long> possibleDateId) {
+        super(PossibleDateRequestDto.class, new Class<?>[]{java.time.LocalDate.class, java.time.LocalTime.class, java.time.LocalTime.class, long.class}, date, startTime, endTime, possibleDateId);
     }
 
 }

--- a/src/main/java/com/soongsil/CoffeeChat/dto/PossibleDateRequestDto.java
+++ b/src/main/java/com/soongsil/CoffeeChat/dto/PossibleDateRequestDto.java
@@ -23,11 +23,14 @@ public class PossibleDateRequestDto {
 	@JsonFormat(pattern = "HH:mm")
 	private LocalTime endTime;
 
+	private Long possibleDateId;
+
 	@QueryProjection
-	public PossibleDateRequestDto(LocalDate date, LocalTime startTime, LocalTime endTime) {
+	public PossibleDateRequestDto(LocalDate date, LocalTime startTime, LocalTime endTime, Long possibleDateId) {
 		this.date = date;
 		this.startTime = startTime;
 		this.endTime = endTime;
+		this.possibleDateId=possibleDateId;
 	}
 
 	public static PossibleDateRequestDto toDto(PossibleDate possibleDate) {

--- a/src/main/java/com/soongsil/CoffeeChat/entity/PossibleDate.java
+++ b/src/main/java/com/soongsil/CoffeeChat/entity/PossibleDate.java
@@ -14,7 +14,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@ToString(of = {"id", "date", "startTime", "endTime", "apply"})
+@ToString(of = {"id", "date", "startTime", "endTime", "isActive"})
 public class PossibleDate {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,6 +37,7 @@ public class PossibleDate {
 
 	@Column
 	@Setter
+	@Builder.Default
 	private boolean isActive=true;
 
 	public static PossibleDate from(PossibleDateRequestDto dto) {

--- a/src/main/java/com/soongsil/CoffeeChat/repository/PossibleDate/PossibleDateRepositoryImpl.java
+++ b/src/main/java/com/soongsil/CoffeeChat/repository/PossibleDate/PossibleDateRepositoryImpl.java
@@ -24,7 +24,8 @@ public class PossibleDateRepositoryImpl implements PossibleDateRepositoryCustom{
                 select(new QPossibleDateRequestDto(
                         possibleDate.date,
                         possibleDate.startTime,
-                        possibleDate.endTime
+                        possibleDate.endTime,
+                        possibleDate.id.as("possibleDateId")
                 ))
                 .from(user)
                 .join(user.mentor, mentor)

--- a/src/main/java/com/soongsil/CoffeeChat/service/ApplicationService.java
+++ b/src/main/java/com/soongsil/CoffeeChat/service/ApplicationService.java
@@ -4,6 +4,7 @@ import com.soongsil.CoffeeChat.entity.*;
 import com.soongsil.CoffeeChat.repository.PossibleDate.PossibleDateRepository;
 import jakarta.mail.MessagingException;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.annotation.Async;
@@ -48,26 +49,33 @@ public class ApplicationService {
 		User findMenteeUser = userRepository.findByUsername(userName);
 		Mentee findMentee = findMenteeUser.getMentee();
 
-		// 사용자가 신청한 시간대에 해당하는 PossibleDate의 Active 변경로직
+// 사용자가 신청한 시간대에 해당하는 PossibleDate의 Active 변경로직
 		LocalTime startTime = request.getStartTime();
-		// 영속성 컨텍스트에서 PossibleDate 엔티티를 모두 가져옴
-		List<PossibleDate> possibleDates = em.createQuery("SELECT p FROM PossibleDate p", PossibleDate.class).getResultList();
 
-		// startTime이 지정된 시간인 엔티티를 필터링
-		Optional<PossibleDate> possibleDateOpt = possibleDates.stream().filter(p -> startTime.equals(p.getStartTime())).findFirst();
-		// 찾은 PossibleDate의 Active상태 변경
+// 특정 mentorId와 startTime을 가진 PossibleDate 엔티티를 가져오는 JPQL 쿼리
+		TypedQuery<PossibleDate> query = em.createQuery(
+				"SELECT p FROM PossibleDate p JOIN p.mentor m WHERE m.id = :mentorId AND p.startTime = :startTime",
+				PossibleDate.class);
+		query.setParameter("mentorId", request.getMentorId());
+		query.setParameter("startTime", startTime);
+
+// 결과를 가져옴
+		Optional<PossibleDate> possibleDateOpt = query.getResultList().stream().findFirst();
+
+// 찾은 PossibleDate의 Active상태 변경
 		if (possibleDateOpt.isPresent()) {
 			PossibleDate possibleDate = possibleDateOpt.get();
+			System.out.println("possibleDate.getId() = " + possibleDate.getId());
 			possibleDate.setActive(false);
 			possibleDateRepository.save(possibleDate);
 		} else {
 			throw new Exception("NOT FOUND"); // 500에러
 		}
 
-		// 성사된 커피챗 생성후 반환
+// 성사된 커피챗 생성후 반환
 		Application savedApplication = applicationRepository.save(request.toEntity(findMentor, findMentee));
 
-		// 비동기 메일 발송 메서드를 프록시를 통해 호출
+// 비동기 메일 발송 메서드를 프록시를 통해 호출
 		ApplicationService proxy = applicationContext.getBean(ApplicationService.class);
 		proxy.sendApplicationMatchedEmailAsync(findMenteeUser.getEmail(), findMentorUser.getName(),
 				findMenteeUser.getName(), savedApplication.getDate(), savedApplication.getStartTime(),
@@ -80,4 +88,5 @@ public class ApplicationService {
 	public void sendApplicationMatchedEmailAsync(String email, String mentorName, String menteeName, LocalDate date, LocalTime startTime, LocalTime endTime) throws MessagingException {
 		emailUtil.sendApplicationMatchedEmail(email, mentorName, menteeName, date, startTime, endTime);
 	}
+
 }


### PR DESCRIPTION
# 🔎 Resolved Issue
fix: 커피챗 성사시 active처리 오류 해결

# 📄 Content
- JPQL의 조건문 부족으로 타 멘토의 동일 시간대의 possibleDate가 active되는 문제 해결