### PR TITLE
feat: mobile 전용 accessToken 발급 api 구현

### DIFF
--- a/src/main/java/com/soongsil/CoffeeChat/config/SecurityConfig.java
+++ b/src/main/java/com/soongsil/CoffeeChat/config/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
 				.successHandler(customSuccessHandler))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()  // 모든 OPTIONS 요청에 대해 인증을 요구하지 않음
-				.requestMatchers("/health-check", "/", "/reissue", "/security-check").permitAll()
+				.requestMatchers("/health-check", "/", "/auth/reissue/**", "/security-check").permitAll()
 				.requestMatchers("/api/v2/users/**", "/auth/**").hasRole("USER")
 				.requestMatchers("/api/v2/possibleDates/**").hasAnyRole("MENTOR", "MENTEE")
 				.requestMatchers("/api/v2/mentors/**").hasAnyRole("MENTOR", "MENTEE")

--- a/src/main/java/com/soongsil/CoffeeChat/config/jwt/JWTFilter.java
+++ b/src/main/java/com/soongsil/CoffeeChat/config/jwt/JWTFilter.java
@@ -37,7 +37,7 @@ public class JWTFilter extends OncePerRequestFilter { //요청당 한번만 실�
 			return;
 		}
 		String path = request.getRequestURI();
-		if (path.startsWith("/health-check") || path.startsWith("/security-check") || path.startsWith("/reissue")) {
+		if (path.startsWith("/health-check") || path.startsWith("/security-check") || path.startsWith("/auth/reissue")) {
 			System.out.println("jwt필터 통과로직");
 			filterChain.doFilter(request, response);
 			return;

--- a/src/main/java/com/soongsil/CoffeeChat/controller/RefreshTokenController.java
+++ b/src/main/java/com/soongsil/CoffeeChat/controller/RefreshTokenController.java
@@ -1,11 +1,14 @@
 package com.soongsil.CoffeeChat.controller;
 
-import com.soongsil.CoffeeChat.controller.handler.ApiResponseGenerator;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.soongsil.CoffeeChat.config.jwt.JWTUtil;
+import com.soongsil.CoffeeChat.controller.handler.ApiResponseGenerator;
+import com.soongsil.CoffeeChat.service.CustomOAuth2UserService;
 import com.soongsil.CoffeeChat.service.RefreshTokenService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,26 +16,38 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @RestController  //RestController=Controller+ResponseBody
+@RequestMapping("/auth")
 @Tag(name = "REFRESHTOKEN", description = "리프레쉬 토큰 관련 api")
+@RequiredArgsConstructor
 public class RefreshTokenController {  //Refresh토큰으로 Access토큰 발급 및 2차회원가입 컨트롤러
 	private final JWTUtil jwtUtil;
 	private final RefreshTokenService refreshTokenService;
 
-	public RefreshTokenController(JWTUtil jwtUtil, RefreshTokenService refreshTokenService) {
-		this.jwtUtil = jwtUtil;
-		this.refreshTokenService = refreshTokenService;
-	}
+	private final CustomOAuth2UserService oAuth2UserService;
 
 	@PostMapping("/reissue")
 	@Operation(summary = "리프레쉬 토큰으로 액세스 토큰 reissue")
 	@ApiResponse(responseCode = "200", description = "헤더 : access, refresh, loginStatus")
-	public ResponseEntity<ApiResponseGenerator<String>> reissue(HttpServletRequest request, HttpServletResponse response) {
+	public ResponseEntity<ApiResponseGenerator<String>> reissue(HttpServletRequest request,
+		HttpServletResponse response) {
 		return ResponseEntity.ok().body(
-				ApiResponseGenerator.onSuccessOK(
-						refreshTokenService.reissueByRefreshToken(request, response)
-				)
+			ApiResponseGenerator.onSuccessOK(
+				refreshTokenService.reissueByRefreshToken(request, response)
+			)
+		);
+	}
+
+	@PostMapping("/reissue/mobile")
+	@Operation(summary = "리소스 서버에서 받은 accessToken으로 서비스 accessToken 발급")
+	@ApiResponse(responseCode = "200", description = "유효한 google accessToken으로 요청시 body로 ROLE_USER 토큰 반환")
+	public ResponseEntity<ApiResponseGenerator<String>> issueAccessToken(@RequestParam String accessToken) {
+		return ResponseEntity.ok().body(
+			ApiResponseGenerator.onSuccessOK(
+				oAuth2UserService.verifyGoogleToken(accessToken)
+			)
 		);
 	}
 }

--- a/src/main/java/com/soongsil/CoffeeChat/controller/exception/enums/RefreshErrorCode.java
+++ b/src/main/java/com/soongsil/CoffeeChat/controller/exception/enums/RefreshErrorCode.java
@@ -12,7 +12,8 @@ public enum RefreshErrorCode {
     REFRESH_NOT_FOUND(HttpStatus.NOT_FOUND, "REFRESH_404", "refresh 토큰이 들어오지 않았습니다."),
     REFRESH_EXPIRED(HttpStatus.FORBIDDEN, "REFRESH_403", "refresh 토큰이 만료되었습니다."),
     REFRESH_NOT_MATCHED(HttpStatus.UNAUTHORIZED, "REFRESH_401", "저장되지 않은 refresh 토큰입니다."),
-    REFRESH_BAD_REQUEST(HttpStatus.BAD_REQUEST, "REFRESH_400", "refresh 토큰이 아닌 다른 종류의 토큰이 들어왔습니다.");
+    REFRESH_BAD_REQUEST(HttpStatus.BAD_REQUEST, "REFRESH_400", "refresh 토큰이 아닌 다른 종류의 토큰이 들어왔습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "GOOGLE_ACCESS_400", "유효하지 않은 Google accessToken입니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final String errorCode;


### PR DESCRIPTION
# 🔎 Resolved Issue
- #142 

# ✅ Title
- mobile 전용 accessToken 발급 api 구현

# 📄 Content
- refresh api url 일부 수정
- api 추가에 따른 `jwtfilter,` `security config` 수정
- google access token 바탕으로 google resource server에 인증 수행 후 user 권한 accessToken 발급하는 api 구현
