### PR TITLE
[FIX] : 멘토 정보 조회시 club 필드 추가반환(#147)

### DIFF
--- a/src/main/java/com/soongsil/CoffeeChat/dto/MentorGetUpdateDetailDto.java
+++ b/src/main/java/com/soongsil/CoffeeChat/dto/MentorGetUpdateDetailDto.java
@@ -3,6 +3,7 @@ package com.soongsil.CoffeeChat.dto;
 import com.querydsl.core.annotations.QueryProjection;
 import com.soongsil.CoffeeChat.entity.Mentor;
 import com.soongsil.CoffeeChat.entity.User;
+import com.soongsil.CoffeeChat.enums.ClubEnum;
 import com.soongsil.CoffeeChat.enums.PartEnum;
 
 import lombok.Builder;
@@ -18,6 +19,7 @@ public class MentorGetUpdateDetailDto {
 	Long mentorId;
 	String mentorName;
 	PartEnum part;
+	ClubEnum club;
 	String introductionTitle;
 	String introductionDescription;
 	String introductionAnswer1;
@@ -30,6 +32,7 @@ public class MentorGetUpdateDetailDto {
 			.mentorName(user.getName())
 			.imageUrl(user.getPicture())
 			.part(mentor.getPart())
+				.club(mentor.getClub())
 			.introductionTitle(mentor.getIntroduction().getTitle())
 			.introductionDescription(mentor.getIntroduction().getDescription())
 			.introductionAnswer1(mentor.getIntroduction().getAnswer1())
@@ -38,12 +41,13 @@ public class MentorGetUpdateDetailDto {
 	}
 
 	@QueryProjection
-	public MentorGetUpdateDetailDto(Long mentorId, String mentorName, PartEnum part, String introductionTitle,
+	public MentorGetUpdateDetailDto(Long mentorId, String mentorName, PartEnum part, ClubEnum club, String introductionTitle,
 		String introductionDescription,
 		String introductionAnswer1, String introductionAnswer2, String imageUrl) {
 		this.mentorId = mentorId;
 		this.mentorName = mentorName;
 		this.part = part;
+		this.club=club;
 		this.introductionTitle = introductionTitle;
 		this.introductionDescription = introductionDescription;
 		this.introductionAnswer1 = introductionAnswer1;

--- a/src/main/java/com/soongsil/CoffeeChat/repository/Mentor/MentorRepositoryImpl.java
+++ b/src/main/java/com/soongsil/CoffeeChat/repository/Mentor/MentorRepositoryImpl.java
@@ -100,6 +100,7 @@ public class MentorRepositoryImpl implements MentorRepositoryCustom {
 				mentor.id.as("mentorId"),
 				user.name.as("mentorName"),
 				mentor.part,
+				mentor.club,
 				introduction.title.as("introductionTitle"),
 				introduction.description.as("introductionDescription"),
 				introduction.answer1.as("introductionAnswer1"),


### PR DESCRIPTION
# 🔎 Resolved Issue
- 멘토 정보 조회시, 멘토의 동아리(club)도 함께 추가반환
- DTO수정

# ✅ Title
- 멘토 정보 조회시 club 필드 추가반환

# 📄 Content
- #147 
