### PR TITLE
feat: 토큰 기반 멘토 가능 시간 조회 API 구현

### DIFF
--- a/src/main/java/com/soongsil/CoffeeChat/controller/PossibleDateController.java
+++ b/src/main/java/com/soongsil/CoffeeChat/controller/PossibleDateController.java
@@ -64,4 +64,19 @@ public class PossibleDateController {
 				possibleDateService.findPossibleDateListByMentor(mentorId))
 		);
 	}
+
+	@GetMapping("")
+	@Operation(summary = "토큰으로 멘토 본인의 커피챗 가능시간 불러오기")
+	@ApiResponse(responseCode = "200", description = "DTO LIST형식으로 정보 반환")
+	public ResponseEntity<ApiResponseGenerator<List<PossibleDateCreateGetResponseDto>>> getPossibleDatesByToken(
+			Authentication authentication
+	) throws Exception {
+		return ResponseEntity.ok().body(
+				ApiResponseGenerator.onSuccessOK(
+						possibleDateService.findMentorPossibleDateListByUsername(
+								getUserNameByAuthentication(authentication)
+						)
+				)
+		);
+	}
 }

--- a/src/main/java/com/soongsil/CoffeeChat/service/PossibleDateService.java
+++ b/src/main/java/com/soongsil/CoffeeChat/service/PossibleDateService.java
@@ -80,4 +80,10 @@ public class PossibleDateService {
 				.build())
 			.collect(Collectors.toList());
 	}
+
+	public List<PossibleDateCreateGetResponseDto> findMentorPossibleDateListByUsername(String username) {
+
+		User user = findUserByUsername(username);
+		return findPossibleDateListByMentor(user.getMentor().getId());
+	}
 }


### PR DESCRIPTION
# 🔎 Resolved Issue
- #184 

# ✅ Title
- 토큰 기반 멘토 가능 시간 조회 API 구현

# 📄 Content
- 멘토 아이디 없이 토큰으로 멘토 본인의 코고 가능 시간을 조회할 수 있습니다.
