### PR TITLE
bug: 모바일 액세스 토큰 발급 시 유저 중복 저장

### DIFF
--- a/src/main/java/com/soongsil/CoffeeChat/controller/exception/enums/UserErrorCode.java
+++ b/src/main/java/com/soongsil/CoffeeChat/controller/exception/enums/UserErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatusCode;
 @RequiredArgsConstructor
 public enum UserErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404", "해당 USER의 엔티티가 존재하지 않습니다."),
-    USER_SMS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "USER_500", "SMS 전송에 실패했습니다.");
+    USER_SMS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "USER_500", "SMS 전송에 실패했습니다."),
+    USER_EXIST(HttpStatus.CONFLICT, "USER_409", "중복 유저가 존재합니다."),
+
+    ;
 
     private final HttpStatusCode httpStatusCode;
     private final String errorCode;

--- a/src/main/java/com/soongsil/CoffeeChat/dto/Oauth/MobileUserDTO.java
+++ b/src/main/java/com/soongsil/CoffeeChat/dto/Oauth/MobileUserDTO.java
@@ -1,0 +1,25 @@
+package com.soongsil.CoffeeChat.dto.Oauth;
+
+import com.soongsil.CoffeeChat.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MobileUserDTO {
+    private String role;
+    private String name;
+    private String username; //스프링 서버 내의 유저 아이디
+    private String email;
+
+    public User toEntity(){
+        return User.builder()
+                .role(this.getRole())
+                .name(this.getName())
+                .username(this.getUsername())
+                .email(this.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/soongsil/CoffeeChat/service/UserService.java
+++ b/src/main/java/com/soongsil/CoffeeChat/service/UserService.java
@@ -5,6 +5,7 @@ import static com.soongsil.CoffeeChat.controller.exception.enums.UserErrorCode.*
 import java.util.HashMap;
 import java.util.Map;
 
+import com.soongsil.CoffeeChat.dto.Oauth.MobileUserDTO;
 import org.springframework.stereotype.Service;
 
 import com.soongsil.CoffeeChat.controller.exception.CustomException;
@@ -131,5 +132,12 @@ public class UserService {
 	public void deleteUser(String username) {
 		User user = findUserByUsername(username);
 		userRepository.delete(user);
+	}
+
+	public void saveMobileUser(MobileUserDTO dto) {
+		if(userRepository.findByUsername(dto.getUsername()).isPresent()){
+			throw new CustomException(USER_EXIST.getHttpStatusCode(), USER_EXIST.getErrorMessage());
+		}
+		userRepository.save(dto.toEntity());
 	}
 }


### PR DESCRIPTION
# 🔎 Resolved Issue
- #186 

# ✅ Title
- 모바일 액세스 토큰 발급 시 유저가 중복으로 저장됨

# 📄 Content
- 디비에 존재하는 유저인지 검사하는 로직 추가
