### PR TITLE
feat: 모바일 토큰 발급 시 신규 계정 여부 추가

### DIFF
--- a/src/main/java/com/soongsil/CoffeeChat/controller/RefreshTokenController.java
+++ b/src/main/java/com/soongsil/CoffeeChat/controller/RefreshTokenController.java
@@ -2,6 +2,7 @@ package com.soongsil.CoffeeChat.controller;
 
 import com.soongsil.CoffeeChat.config.jwt.JWTUtil;
 import com.soongsil.CoffeeChat.controller.handler.ApiResponseGenerator;
+import com.soongsil.CoffeeChat.dto.MobileTokenResponseDTO;
 import com.soongsil.CoffeeChat.service.CustomOAuth2UserService;
 import com.soongsil.CoffeeChat.service.RefreshTokenService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,8 +42,8 @@ public class RefreshTokenController {  //Refresh토큰으로 Access토큰 발급
     @PostMapping("/issue/mobile")
     @Operation(summary = "[MOBILE] google 서버에서 받은 accessToken으로 서비스 accessToken 발급")
     @ApiResponse(responseCode = "200", description = "유효한 google accessToken으로 요청시 body로 ROLE_USER 토큰 반환")
-    public ResponseEntity<ApiResponseGenerator<Map<String, String>>> issueAccessToken(@RequestParam String accessToken,
-                                                                                      @RequestParam String name) {
+    public ResponseEntity<ApiResponseGenerator<MobileTokenResponseDTO>> issueAccessToken(@RequestParam String accessToken,
+                                                                                         @RequestParam String name) {
         return ResponseEntity.ok().body(
                 ApiResponseGenerator.onSuccessOK(
                         oAuth2UserService.verifyGoogleToken(accessToken, name)

--- a/src/main/java/com/soongsil/CoffeeChat/dto/MobileTokenResponseDTO.java
+++ b/src/main/java/com/soongsil/CoffeeChat/dto/MobileTokenResponseDTO.java
@@ -1,0 +1,10 @@
+package com.soongsil.CoffeeChat.dto;
+
+import lombok.Builder;
+
+@Builder
+public class MobileTokenResponseDTO {
+    private String accessToken;
+    private String refreshToken;
+    private boolean isNewAccount;
+}

--- a/src/main/java/com/soongsil/CoffeeChat/dto/Oauth/MobileUserDTO.java
+++ b/src/main/java/com/soongsil/CoffeeChat/dto/Oauth/MobileUserDTO.java
@@ -13,6 +13,7 @@ public class MobileUserDTO {
     private String name;
     private String username; //스프링 서버 내의 유저 아이디
     private String email;
+    private boolean isNewAccount;
 
     public User toEntity(){
         return User.builder()

--- a/src/main/java/com/soongsil/CoffeeChat/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/soongsil/CoffeeChat/service/CustomOAuth2UserService.java
@@ -117,7 +117,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .build();
 
                 if(!userRepository.findByUsername(mobileUserDTO.getUsername()).isPresent()){
-                    userService.saveMobileUser(mobileUserDTO);
                     mobileUserDTO.setNewAccount(true);
                 }
 

--- a/src/main/java/com/soongsil/CoffeeChat/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/soongsil/CoffeeChat/service/CustomOAuth2UserService.java
@@ -2,6 +2,7 @@ package com.soongsil.CoffeeChat.service;
 
 import com.soongsil.CoffeeChat.config.jwt.JWTUtil;
 import com.soongsil.CoffeeChat.controller.exception.CustomException;
+import com.soongsil.CoffeeChat.dto.MobileTokenResponseDTO;
 import com.soongsil.CoffeeChat.dto.Oauth.*;
 import com.soongsil.CoffeeChat.entity.User;
 import com.soongsil.CoffeeChat.repository.User.UserRepository;
@@ -98,7 +99,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }
     }
 
-    public Map<String,String> verifyGoogleToken(String accessToken, String name) {
+    public MobileTokenResponseDTO verifyGoogleToken(String accessToken, String name) {
         log.info("[*] TOKEN>>>>> " + accessToken);
         RestTemplate restTemplate = new RestTemplate();
         String url = GOOGLE_TOKEN_INFO_URL + accessToken;
@@ -112,7 +113,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .username((String) tokenInfo.get("sub"))
                         .name(name)
                         .role("ROLE_USER")
+                        .isNewAccount(false)
                         .build();
+
+                if(!userRepository.findByUsername(mobileUserDTO.getUsername()).isPresent()){
+                    userService.saveMobileUser(mobileUserDTO);
+                    mobileUserDTO.setNewAccount(true);
+                }
 
                 userService.saveMobileUser(mobileUserDTO);
 
@@ -124,12 +131,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 // Refresh 토큰을 Redis 또는 DB에 저장 (선택적)
                 refreshTokenService.addRefreshEntity(mobileUserDTO.getUsername(), newRefreshToken, 86400000L); // 24 hrs
 
-                // Access 및 Refresh 토큰 반환
-                Map<String, String> tokens = new HashMap<>();
-                tokens.put("accessToken", newAccessToken);
-                tokens.put("refreshToken", newRefreshToken);
-
-                return tokens;
+                // access, refresh 토큰 반환
+                return MobileTokenResponseDTO.builder()
+                        .refreshToken(newRefreshToken)
+                        .accessToken(newAccessToken)
+                        .isNewAccount(mobileUserDTO.isNewAccount())
+                        .build();
             } else {
                 log.error("===== Invalid token info ===== " + tokenInfo);
                 throw new CustomException(INVALID_TOKEN.getHttpStatusCode(), INVALID_TOKEN.getErrorMessage());

--- a/src/main/java/com/soongsil/CoffeeChat/service/UserService.java
+++ b/src/main/java/com/soongsil/CoffeeChat/service/UserService.java
@@ -136,6 +136,8 @@ public class UserService {
 
 	@Transactional
 	public void saveMobileUser(MobileUserDTO dto) {
-		userRepository.save(dto.toEntity());
+		if(!userRepository.findByUsername(dto.getUsername()).isPresent()){
+			userRepository.save(dto.toEntity());
+		}
 	}
 }

--- a/src/main/java/com/soongsil/CoffeeChat/service/UserService.java
+++ b/src/main/java/com/soongsil/CoffeeChat/service/UserService.java
@@ -136,8 +136,6 @@ public class UserService {
 
 	@Transactional
 	public void saveMobileUser(MobileUserDTO dto) {
-		if(!userRepository.findByUsername(dto.getUsername()).isPresent()){
-			userRepository.save(dto.toEntity());
-		}
+		userRepository.save(dto.toEntity());
 	}
 }


### PR DESCRIPTION
# 🔎 Resolved Issue
- #193 

# ✅ Title
- 모바일 토큰 발급 시 신규 계정 여부 추가

# 📄 Content
- 모바일 토큰 발급 api 응답 dto 생성 (refresh 토큰, access 토큰, 신규 계정 여부)
- 모바일 토큰 발급 api의 Response Body에 신규 유저인지, 기존 유저인지 구분하는 isNewAccount 필드 추가
