### PR TITLE
fix: 도커 시스템 종료 대신 이미지와 컨테이너만 종료

### DIFF
--- a/.github/workflows/cogo_cd.yml
+++ b/.github/workflows/cogo_cd.yml
@@ -90,4 +90,6 @@ jobs:
         run: sudo docker logs cogo || true
 
       - name: Delete old docker image
-        run: sudo docker system prune -f
+        run:
+          sudo docker container prune -f
+          sudo docker image prune -f


### PR DESCRIPTION
# 🔎 Resolved Issue
- tmp

# ✅ Title
- tmp

# 📄 Content
- tmp
