### PR TITLE
feat: 채팅방 안 읽은 메시지 수 추가

### DIFF
--- a/src/main/java/com/soongsil/CoffeeChat/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/soongsil/CoffeeChat/domain/chat/controller/ChatController.java
@@ -68,7 +68,8 @@ public class ChatController {
             @RequestParam(required = false) Long cursorChatId,
             @RequestParam(defaultValue = "50") int size) {
         return ResponseEntity.ok(
-                chatService.getChatMessagesByCursor(username, roomId, cursorCreatedAt, cursorChatId, size));
+                chatService.getChatMessagesByCursor(
+                        username, roomId, cursorCreatedAt, cursorChatId, size));
     }
 
     @PostMapping("/rooms/{roomId}/leave")
@@ -76,6 +77,14 @@ public class ChatController {
     public ResponseEntity<Void> leaveChatRoom(
             @Parameter(hidden = true) @CurrentUsername String username, @PathVariable Long roomId) {
         chatService.leaveChatRoom(username, roomId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/rooms/{roomId}/read")
+    @Operation(summary = "채팅방 읽음 처리")
+    public ResponseEntity<Void> readChatRoom(
+            @Parameter(hidden = true) @CurrentUsername String username, @PathVariable Long roomId) {
+        chatService.readChatRoom(username, roomId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/soongsil/CoffeeChat/domain/chat/dto/ChatConverter.java
+++ b/src/main/java/com/soongsil/CoffeeChat/domain/chat/dto/ChatConverter.java
@@ -21,13 +21,15 @@ public class ChatConverter {
             ChatRoom chatRoom,
             String lastChat,
             List<ChatParticipantResponse> participants,
-            LocalDateTime updatedAt) {
+            LocalDateTime updatedAt,
+            Long unreadCount) {
 
         return ChatRoomResponse.builder()
                 .roomId(chatRoom.getId())
                 .lastChat(lastChat)
                 .participants(participants)
                 .updatedAt(updatedAt)
+                .unreadCount(unreadCount)
                 .build();
     }
 
@@ -111,7 +113,8 @@ public class ChatConverter {
             Page<ChatRoom> chatRoomPage,
             List<String> lastChats,
             List<List<ChatParticipantResponse>> partiesList,
-            List<LocalDateTime> updatedAts) {
+            List<LocalDateTime> updatedAts,
+            List<Long> unreadCounts) {
 
         final List<ChatRoom> rooms = chatRoomPage.getContent();
         final int n = rooms.size();
@@ -139,7 +142,15 @@ public class ChatConverter {
                                                             && updatedAts.get(i) != null)
                                                     ? updatedAts.get(i)
                                                     : room.getUpdatedDate();
-                                    return toChatRoomResponse(room, last, parties, updatedAt);
+
+                                    Long unreadCount =
+                                            (unreadCounts != null
+                                                            && i < unreadCounts.size()
+                                                            && unreadCounts.get(i) != null)
+                                                    ? unreadCounts.get(i)
+                                                    : 0L;
+                                    return toChatRoomResponse(
+                                            room, last, parties, updatedAt, unreadCount);
                                 })
                         .toList();
 

--- a/src/main/java/com/soongsil/CoffeeChat/domain/chat/dto/ChatResponse.java
+++ b/src/main/java/com/soongsil/CoffeeChat/domain/chat/dto/ChatResponse.java
@@ -32,6 +32,7 @@ public class ChatResponse {
         private Long roomId;
         private String lastChat;
         private LocalDateTime updatedAt;
+        private Long unreadCount;
 
         private List<ChatParticipantResponse> participants;
     }

--- a/src/main/java/com/soongsil/CoffeeChat/domain/chat/entity/ChatRoomUser.java
+++ b/src/main/java/com/soongsil/CoffeeChat/domain/chat/entity/ChatRoomUser.java
@@ -25,4 +25,18 @@ public class ChatRoomUser {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @Column(name = "last_read_chat_id")
+    private Long lastReadChatId;
+
+    public void updateLastReadChatId(Long chatId) {
+        if (chatId == null) {
+            return;
+        }
+
+        if (lastReadChatId == null || chatId > lastReadChatId) {
+            lastReadChatId = chatId;
+        }
+    }
+
 }

--- a/src/main/java/com/soongsil/CoffeeChat/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/soongsil/CoffeeChat/domain/chat/repository/ChatRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.soongsil.CoffeeChat.domain.chat.entity.Chat;
 
@@ -17,4 +19,19 @@ public interface ChatRepository extends JpaRepository<Chat, Long>, ChatRepositor
             Long roomId, LocalDateTime before, Pageable pageable);
 
     Optional<Chat> findTopByChatRoomIdOrderByCreatedAtDesc(Long roomId);
+
+    Optional<Chat> findTopByChatRoomIdOrderByCreatedAtDescIdDesc(Long roomId);
+
+    @Query(
+            """
+            SELECT COUNT(c)
+            FROM Chat c
+            WHERE c.chatRoom.id = :roomId
+              AND c.sender.id <> :userId
+              AND (:lastReadChatId IS NULL OR c.id > :lastReadChatId)
+            """)
+    Long countUnreadMessages(
+            @Param("roomId") Long roomId,
+            @Param("userId") Long userId,
+            @Param("lastReadChatId") Long lastReadChatId);
 }

--- a/src/main/java/com/soongsil/CoffeeChat/domain/chat/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/soongsil/CoffeeChat/domain/chat/repository/ChatRoomUserRepository.java
@@ -12,4 +12,6 @@ public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long
     List<ChatRoomUser> findByChatRoomId(Long roomId);
 
     Optional<ChatRoomUser> findByChatRoomIdAndUserId(Long roomId, Long userId);
+
+    List<ChatRoomUser> findByUserIdAndChatRoomIdIn(Long userId, List<Long> roomIds);
 }

--- a/src/main/java/com/soongsil/CoffeeChat/domain/chat/service/ChatService.java
+++ b/src/main/java/com/soongsil/CoffeeChat/domain/chat/service/ChatService.java
@@ -3,7 +3,10 @@ package com.soongsil.CoffeeChat.domain.chat.service;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.springframework.data.domain.Page;
@@ -66,6 +69,15 @@ public class ChatService {
 
         Page<ChatRoom> chatRooms =
                 chatRoomRepository.findActiveChatRoomsByUserId(currentUser.getId(), pageable);
+        List<Long> roomIds = chatRooms.getContent().stream().map(ChatRoom::getId).toList();
+        Map<Long, ChatRoomUser> participantMap =
+                chatRoomUserRepository
+                        .findByUserIdAndChatRoomIdIn(currentUser.getId(), roomIds)
+                        .stream()
+                        .collect(
+                                Collectors.toMap(
+                                        participant -> participant.getChatRoom().getId(),
+                                        Function.identity()));
 
         List<Optional<Chat>> lastChatOptList =
                 chatRooms.getContent().stream()
@@ -108,7 +120,25 @@ public class ChatService {
                                     return List.of(otherUserDto);
                                 })
                         .toList();
-        return ChatConverter.toChatRoomPageResponse(chatRooms, lastChats, partiesList, updatedAts);
+
+        List<Long> unreadCounts =
+                chatRooms.getContent().stream()
+                        .map(
+                                room -> {
+                                    ChatRoomUser participant = participantMap.get(room.getId());
+                                    if (participant == null) {
+                                        throw new GlobalException(
+                                                GlobalErrorCode.CHATROOM_NOT_PARTICIPANT);
+                                    }
+                                    return chatRepository.countUnreadMessages(
+                                            room.getId(),
+                                            currentUser.getId(),
+                                            participant.getLastReadChatId());
+                                })
+                        .toList();
+
+        return ChatConverter.toChatRoomPageResponse(
+                chatRooms, lastChats, partiesList, updatedAts, unreadCounts);
     }
 
     @Transactional
@@ -158,7 +188,6 @@ public class ChatService {
 
         return ChatConverter.toChatRoomDetailResponse(chatRoom);
     }
-
 
     @Transactional(readOnly = true)
     public ChatResponse.ChatMessagePageResponse getChatMessages(
@@ -223,6 +252,27 @@ public class ChatService {
                             roomId, cursorCreatedAt, cursorChatId, size + 1);
         }
         return ChatConverter.toChatMessageCursorResponse(chats, size);
+    }
+
+    @Transactional
+    public void readChatRoom(String username, Long roomId) {
+        User currentUser = findUserByUsername(username);
+
+        if (!chatRoomRepository.existsById(roomId)) {
+            throw new GlobalException(GlobalErrorCode.CHATROOM_NOT_FOUND);
+        }
+
+        ChatRoomUser participant =
+                chatRoomUserRepository
+                        .findByChatRoomIdAndUserId(roomId, currentUser.getId())
+                        .orElseThrow(
+                                () ->
+                                        new GlobalException(
+                                                GlobalErrorCode.CHATROOM_NOT_PARTICIPANT));
+
+        chatRepository
+                .findTopByChatRoomIdOrderByCreatedAtDescIdDesc(roomId)
+                .ifPresent(chat -> participant.updateLastReadChatId(chat.getId()));
     }
 
     @Transactional

--- a/src/main/resources/db/migration/V2__add_last_read_chat_id_to_chat_room_user.sql
+++ b/src/main/resources/db/migration/V2__add_last_read_chat_id_to_chat_room_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ChatRoomUser
+    ADD COLUMN last_read_chat_id BIGINT NULL;


### PR DESCRIPTION
# 🔎 Resolved Issue
- #291 

# ✅ Title
- feat: 채팅방 안 읽은 메시지 수 추가

# 📄 Content
- 채팅방 참여자별 마지막 읽은 메시지 ID를 저장하도록 `lastReadChatId` 추가
- 채팅방 목록 응답에 `unreadCount` 추가
- `POST /api/v2/chat/rooms/{roomId}/read` API 추가
- 현재 유저가 보낸 메시지는 안 읽은 메시지 수에서 제외
- 읽음 처리 후 해당 채팅방의 안 읽은 메시지 수가 0으로 갱신되도록 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 채팅방을 읽음으로 표시하는 기능 추가 - 사용자가 특정 채팅방의 메시지를 읽음 처리할 수 있습니다.
* 읽지 않은 메시지 수 추적 - 각 채팅방별로 읽지 않은 메시지의 개수를 표시하여 사용자가 미확인 메시지를 한눈에 파악할 수 있습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Soongsil-CoffeeChat/COGO-DEV-server/pull/292)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->