### PR TITLE
refactor: local 환경 JWT 필터 추가 및 유저 조회 쿼리 JPQL 변경

### DIFF
--- a/src/main/java/com/soongsil/CoffeeChat/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/soongsil/CoffeeChat/domain/user/repository/UserRepository.java
@@ -10,7 +10,7 @@ import com.soongsil.CoffeeChat.domain.mentor.entity.Mentor;
 import com.soongsil.CoffeeChat.domain.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
-    @Query(value = "select * from User where username = :username", nativeQuery = true)
+    @Query("select u from User u where u.username = :username")
     Optional<User> findByUsernameWithDeleted(@Param("username") String username);
 
     Optional<User> findByUsernameAndIsDeletedFalse(String username);

--- a/src/main/java/com/soongsil/CoffeeChat/global/security/SecurityConfig.java
+++ b/src/main/java/com/soongsil/CoffeeChat/global/security/SecurityConfig.java
@@ -95,7 +95,11 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtUtil),
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(authExceptionHandlingFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }


### PR DESCRIPTION
# 🔎 Resolved Issue
- #294 
- 로컬 환경에서 UserRepository의 native query가 User 대문자 테이블명을 직접 참조해 발생하던 문제 해결
- local profile의 SecurityConfig에 JWT 관련 필터를 추가했습니다.

# ✅ Title
- refactor: local 환경 JWT 필터 복구 및 유저 조회 쿼리 JPQL 변경

# 📄 Content
- `UserRepository.findByUsernameWithDeleted`의 native query를 JPQL로 변경했습니다.
- local profile의 `SecurityConfig`에 JWT 관련 필터를 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 데이터베이스 쿼리 처리 방식 최적화
  * 보안 필터 체인 개선으로 인증 및 예외 처리 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Soongsil-CoffeeChat/COGO-DEV-server/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->